### PR TITLE
fixed bug isse

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.0'
 gem 'bcrypt', '~> 3.1.7'
+gem 'time_ago_in_words', '~> 0.1.1'
 
 group :development, :test do
   gem "rspec-rails", "3.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       activesupport (= 4.1.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.3.2)
+    rake (10.5.0)
     rspec-collection_matchers (1.0.0)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.0.4)
@@ -121,6 +121,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
+    time_ago_in_words (0.1.1)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -146,4 +147,8 @@ DEPENDENCIES
   rspec-collection_matchers (~> 1.0.0)
   rspec-rails (= 3.0.1)
   sass-rails (~> 4.0.3)
+  time_ago_in_words (~> 0.1.1)
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.11.2

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,6 +8,7 @@ class SessionsController < ApplicationController
   def create
     @user = User.find_by(email: params[:user][:email])
     if @user && @user.authenticate(params[:user][:password])
+
       session[:user_id] = @user.id
       redirect_to root_path
     else

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -9,7 +9,10 @@
       </footer>
     </blockquote>
     <div class="created">
-      <%= time_ago_in_words(quote.created_at) %> ago
-    </div>
+      <% if quote.created_at %>
+        <%= time_ago_in_words(quote.created_at) %> ago
+      <% else %>
+        ago
+      <% end %>
   </section>
 <% end %>

--- a/spec/features/auth_spec.rb
+++ b/spec/features/auth_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'capybara/rails'
+require 'time_ago_in_words'
 
 feature 'Auth' do
 

--- a/spec/features/quotes_spec.rb
+++ b/spec/features/quotes_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'capybara/rails'
+require 'time_ago_in_words'
 
 feature 'Auth' do
 


### PR DESCRIPTION
Fixed a dependency and null/undefined issue. Added the time_ago_in_words module inside of the gem file in order for the app to gain access to the function. Then I had to add an if else statement in order to display a different message for each data's lack of timestamp. In order to reproduce the bug and to prevent it in the future, the time_ago_in_words module must be deleted from the gem file and then erase the if else statement. This will result in two errors to occur: 1.) without the lack of time_ago_in_words module inside the gem file, the app will not have access to that method. 2.) Deleting the if else statement will cause a null or "nil" in ruby because some of the data entries do not have a timestamp and the time_ago_in_words can not be passed an undefined argument. 
