### PR TITLE
Ana login fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :development, :test do
   gem "rspec-rails", "3.0.1"
   gem 'rspec-collection_matchers', '~> 1.0.0'
   gem "capybara", "2.3.0"
-  gem 'time_ago_in_words', '~> 0.1.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,11 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.0'
 gem 'bcrypt', '~> 3.1.7'
+gem 'time_ago_in_words', '~> 0.1.1'
 
 group :development, :test do
   gem "rspec-rails", "3.0.1"
   gem 'rspec-collection_matchers', '~> 1.0.0'
   gem "capybara", "2.3.0"
+  gem 'time_ago_in_words', '~> 0.1.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       activesupport (= 4.1.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.3.2)
+    rake (10.4.2)
     rspec-collection_matchers (1.0.0)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.0.4)
@@ -121,6 +121,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
+    time_ago_in_words (0.1.1)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -146,4 +147,8 @@ DEPENDENCIES
   rspec-collection_matchers (~> 1.0.0)
   rspec-rails (= 3.0.1)
   sass-rails (~> 4.0.3)
+  time_ago_in_words (~> 0.1.1)
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.11.2

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
 //= require jquery
 //= require jquery_ujs
 //= require_tree .
+

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,3 @@
 //= require jquery
 //= require jquery_ujs
 //= require_tree .
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+	require 'date'
+	require 'time_ago_in_words'
 end
+

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,3 +1,2 @@
 class Quote < ActiveRecord::Base
-	
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,3 +1,3 @@
 class Quote < ActiveRecord::Base
-
+	include ActionView::Helpers::DateHelper
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,3 +1,3 @@
 class Quote < ActiveRecord::Base
-	include ActionView::Helpers::DateHelper
+	
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,5 +25,6 @@
     <%= yield %>
   </div>
 </main>
+
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,5 @@
     <%= yield %>
   </div>
 </main>
-
 </body>
 </html>

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -9,7 +9,7 @@
       </footer>
     </blockquote>
     <div class="created">
-      <%= time_ago_in_words(quote.created_at) unless quote.created_at.blank? %> ago
+      <%= time_ago_in_words(quote.created_at || Time.now) %> ago
 
 
     </div>

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -9,7 +9,9 @@
       </footer>
     </blockquote>
     <div class="created">
-      <%= time_ago_in_words(quote.created_at) %> ago
+      <%= time_ago_in_words(quote.created_at) unless quote.created_at.blank? %> ago
+
+
     </div>
   </section>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,3 +28,4 @@ module RailsPractice
     # config.i18n.default_locale = :de
   end
 end
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,4 +28,3 @@ module RailsPractice
     # config.i18n.default_locale = :de
   end
 end
-


### PR DESCRIPTION
## BUG FIX STEPS:
### FIRST BUG - LOGIN ERROR:
- Once we reproduced the login error, we found that there was an undefined method in the index file.
- The login error pointed to the 'Time_Ago_in_words' method.
- Defined it as a function in the app helper file (helpers/application_helper.rb). This fixed the login error. 
### SECOND BUG - TIMESTAMP:
- Realized that 'Time_ago_in_words' does not need to be defined (it is already native to Ruby) so we instead required it in the same file, along with 'date'. 
- Added an 'unless' statement to the views/index file in order to nullify comments that have no timestamp: 
      '<%= time_ago_in_words(quote.created_at) unless quote.created_at.blank? %> ago'
