### PR TITLE
Harlem date bug fix

### DIFF
--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,3 +1,3 @@
 class Quote < ActiveRecord::Base
-
+	validates :text, :author, :created_at, presence: true
 end

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -9,7 +9,11 @@
       </footer>
     </blockquote>
     <div class="created">
-      <%= time_ago_in_words(quote.created_at) %> ago
+      <% if quote.created_at%>
+        <%= time_ago_in_words(quote.created_at) %> ago
+      <% else %>
+      less than a minute ago
+      <% end %>
     </div>
   </section>
 <% end %>

--- a/db/production.sql
+++ b/db/production.sql
@@ -8,8 +8,8 @@ SET client_min_messages = warning;
 SET search_path = public, pg_catalog;
 
 COPY quotes (id, text, author, created_at, updated_at) FROM stdin;
-1	People who think they know everything are a great annoyance to those of us who do.	Isaac Asimov	\N	\N
-2	As a child my family's menu consisted of two choices: take it or leave it.	Buddy Hackett	\N	\N
+1	People who think they know everything are a great annoyance to those of us who do.	Isaac Asimov	2014-07-12 03:40:54.4157	2014-07-12 03:40:54.4157
+2	As a child my family's menu consisted of two choices: take it or leave it.	Buddy Hackett	2014-07-12 03:40:54.4157	2014-07-12 03:40:54.4157
 3	My fake plants died because I did not pretend to water them.	Mitch Hedberg	2014-07-12 03:40:54.405448	2014-07-12 03:40:54.405448
 4	If the facts don't fit the theory, change the facts.	Albert Einstein	2014-07-12 03:40:54.4157	2014-07-12 03:40:54.4157
 \.

--- a/spec/features/date_spec.rb
+++ b/spec/features/date_spec.rb
@@ -17,7 +17,7 @@ feature 'created_at' do
   end
 
 	scenario 'Users can view less than a minute ago for quotes without created_at' do
-		create_user email: "user@example.com"
+	create_user email: "user@example.com"
     Quote.create!(text: %Q{Something pithy})
     Quote.create!(text: %Q{Something cool})
 
@@ -29,4 +29,19 @@ feature 'created_at' do
 
     expect(page).to have_content("less than a minute ago")
   end
+
+    scenario 'Users can view less than a minute ago for quotes without created_at' do
+    create_user email: "user@example.com"
+    Quote.create!(text: %Q{Something pithy}, author: %Q{Buddy Hackett}, created_at: (Date.today-1), updated_at: (Date.today-1))
+
+    visit root_path
+    click_on "Login"
+    fill_in "Email", with: "user@example.com"
+    fill_in "Password", with: "password"
+    click_on "Login"
+
+    expect(page).to have_content("2 days ago")
+  end
+
+
 end

--- a/spec/features/date_spec.rb
+++ b/spec/features/date_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'capybara/rails'
+
+feature 'created_at' do
+
+	scenario 'Users can view less than a minute ago for quotes without created_at' do
+		create_user email: "user@example.com"
+    Quote.create!(text: %Q{Something pithy})
+    Quote.create!(text: %Q{Something cool})
+
+    visit root_path
+    click_on "Login"
+    fill_in "Email", with: "user@example.com"
+    fill_in "Password", with: "password"
+    click_on "Login"
+
+    expect(page).to have_content("less than a minute ago")
+  end
+end

--- a/spec/features/date_spec.rb
+++ b/spec/features/date_spec.rb
@@ -4,8 +4,8 @@ require 'capybara/rails'
 feature 'created_at' do
     scenario 'div.created will render' do
     create_user email: "user@example.com"
-    Quote.create!(text: %Q{Something pithy})
-    Quote.create!(text: %Q{Something cool})
+    Quote.create!(text: %Q{Something pithy}, author: %Q{Buddy Hackett}, created_at: (Date.today-1), updated_at: (Date.today-1))
+    Quote.create!(text: %Q{Something cool}, author: %Q{Buddy Hackett}, created_at: (Date.today-1), updated_at: (Date.today-1))
 
     visit root_path
     click_on "Login"
@@ -16,21 +16,7 @@ feature 'created_at' do
     expect(page).to have_selector("div.created", text: /.+/)
   end
 
-	scenario 'Users can view less than a minute ago for quotes without created_at' do
-	create_user email: "user@example.com"
-    Quote.create!(text: %Q{Something pithy})
-    Quote.create!(text: %Q{Something cool})
-
-    visit root_path
-    click_on "Login"
-    fill_in "Email", with: "user@example.com"
-    fill_in "Password", with: "password"
-    click_on "Login"
-
-    expect(page).to have_content("less than a minute ago")
-  end
-
-    scenario 'Users can view less than a minute ago for quotes without created_at' do
+    scenario 'Users can view relative timestamp' do
     create_user email: "user@example.com"
     Quote.create!(text: %Q{Something pithy}, author: %Q{Buddy Hackett}, created_at: (Date.today-1), updated_at: (Date.today-1))
 

--- a/spec/features/date_spec.rb
+++ b/spec/features/date_spec.rb
@@ -2,6 +2,19 @@ require 'rails_helper'
 require 'capybara/rails'
 
 feature 'created_at' do
+    scenario 'div.created will render' do
+    create_user email: "user@example.com"
+    Quote.create!(text: %Q{Something pithy})
+    Quote.create!(text: %Q{Something cool})
+
+    visit root_path
+    click_on "Login"
+    fill_in "Email", with: "user@example.com"
+    fill_in "Password", with: "password"
+    click_on "Login"
+
+    expect(page).to have_selector("div.created", text: /.+/)
+  end
 
 	scenario 'Users can view less than a minute ago for quotes without created_at' do
 		create_user email: "user@example.com"

--- a/spec/features/quotes_spec.rb
+++ b/spec/features/quotes_spec.rb
@@ -5,8 +5,7 @@ feature 'Auth' do
 
   scenario 'Users can view quotes' do
     create_user email: "user@example.com"
-    Quote.create!(text: %Q{Something pithy})
-    Quote.create!(text: %Q{Something cool})
+    Quote.create!(text: %Q{Something pithy}, author: %Q{Buddy Hackett}, created_at: (Date.today-1), updated_at: (Date.today-1))
 
     visit root_path
     click_on "Login"
@@ -15,7 +14,6 @@ feature 'Auth' do
     click_on "Login"
 
     expect(page).to have_content("Something pithy")
-    expect(page).to have_content("Something cool")
   end
 
 end


### PR DESCRIPTION
The current bug is in the master codebase already -- NoMethodError in Quotes#index. This behavior results because 2 of the quotes in the current migration do not have created_at or updated_at timestamps. I fixed the bug by writing an if/else statement to account for use cases where the quotes don't have timestamps.
