### PR TITLE
Bug fix

### DIFF
--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -9,7 +9,7 @@
       </footer>
     </blockquote>
     <div class="created">
-       <%= time_ago_in_words(quote.created_at) unless quote.created_at.blank?%> ago
+      <%= time_ago_in_words(quote.created_at) unless quote.created_at.blank?%> ago
     </div>
   </section>
 <% end %>

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -9,7 +9,7 @@
       </footer>
     </blockquote>
     <div class="created">
-      <%= time_ago_in_words(quote.created_at) %> ago
+       <%= time_ago_in_words(quote.created_at) unless quote.created_at.blank?%> ago
     </div>
   </section>
 <% end %>


### PR DESCRIPTION
Quotes creation date is now displaying as relative time. Log-in works and page does not blow up. 
Some items do not contain a time/date. This may need to be fixed on the database side of things.

Cheers.  
