### PR TITLE
Lissa fix bug01

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.3)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -147,3 +147,6 @@ DEPENDENCIES
   rspec-rails (= 3.0.1)
   sass-rails (~> 4.0.3)
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.11.2

--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -1,5 +1,4 @@
 class QuotesController < ApplicationController
-
   def index
     @quotes = Quote.all
   end

--- a/app/views/quotes/index.html.erb
+++ b/app/views/quotes/index.html.erb
@@ -9,7 +9,7 @@
       </footer>
     </blockquote>
     <div class="created">
-      <%= time_ago_in_words(quote.created_at) %> ago
+      <%= time_ago_in_words(quote.created_at) unless quote.created_at.blank? %> ago
     </div>
   </section>
 <% end %>

--- a/spec/features/quotes_spec.rb
+++ b/spec/features/quotes_spec.rb
@@ -18,4 +18,17 @@ feature 'Auth' do
     expect(page).to have_content("Something cool")
   end
 
+  scenario 'Users can see a quote creation date' do
+    create_user email: "user@example.com"
+    Quote.create!(text: %Q{Something pithy}, author: %Q{Someone}, created_at: (Date.today-6))
+
+    visit root_path
+    click_on "Login"
+    fill_in "Email", with: "user@example.com"
+    fill_in "Password", with: "password"
+    click_on "Login"
+
+    expect(page).to have_content("7 days ago")
+  end
+
 end


### PR DESCRIPTION
This is a fix for a bug that causes the site to crash upon login. Some of the quotes data in the database does not include a 'created_at' property, so upon login the page was crashing when trying to display the null value. I added an unless clause to index.html.erb so that if the field is null, it doesn't cause the site to crash. I also added a test to check if the date was properly displaying when present in the database.
