### PR TITLE
bug fix

### DIFF
--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,3 +1,3 @@
 class Quote < ActiveRecord::Base
-
+	validates :text, :author, :created_at, presence: true
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,3 +1,3 @@
 class Quote < ActiveRecord::Base
-	validates :text, :author, :created_at, presence: true
+
 end

--- a/db/production.sql
+++ b/db/production.sql
@@ -8,8 +8,8 @@ SET client_min_messages = warning;
 SET search_path = public, pg_catalog;
 
 COPY quotes (id, text, author, created_at, updated_at) FROM stdin;
-1	People who think they know everything are a great annoyance to those of us who do.	Isaac Asimov	2016-01-01 03:40:54.405448	2016-01-11 03:40:54.405448
-2	As a child my family's menu consisted of two choices: take it or leave it.	Buddy Hackett	2015-06-12 03:40:54.405448	2016-01-12 03:40:54.405448
+1	People who think they know everything are a great annoyance to those of us who do.	Isaac Asimov	now()	now()
+2	As a child my family's menu consisted of two choices: take it or leave it.	Buddy Hackett	now()	now()
 3	My fake plants died because I did not pretend to water them.	Mitch Hedberg	2014-07-12 03:40:54.405448	2014-07-12 03:40:54.405448
 4	If the facts don't fit the theory, change the facts.	Albert Einstein	2014-07-12 03:40:54.4157	2014-07-12 03:40:54.4157
 \.

--- a/db/production.sql
+++ b/db/production.sql
@@ -8,8 +8,8 @@ SET client_min_messages = warning;
 SET search_path = public, pg_catalog;
 
 COPY quotes (id, text, author, created_at, updated_at) FROM stdin;
-1	People who think they know everything are a great annoyance to those of us who do.	Isaac Asimov	\N	\N
-2	As a child my family's menu consisted of two choices: take it or leave it.	Buddy Hackett	\N	\N
+1	People who think they know everything are a great annoyance to those of us who do.	Isaac Asimov	2016-01-01 03:40:54.405448	2016-01-11 03:40:54.405448
+2	As a child my family's menu consisted of two choices: take it or leave it.	Buddy Hackett	2015-06-12 03:40:54.405448	2016-01-12 03:40:54.405448
 3	My fake plants died because I did not pretend to water them.	Mitch Hedberg	2014-07-12 03:40:54.405448	2014-07-12 03:40:54.405448
 4	If the facts don't fit the theory, change the facts.	Albert Einstein	2014-07-12 03:40:54.4157	2014-07-12 03:40:54.4157
 \.

--- a/spec/features/quotes_spec.rb
+++ b/spec/features/quotes_spec.rb
@@ -4,18 +4,17 @@ require 'capybara/rails'
 feature 'Auth' do
 
   scenario 'Users can view quotes' do
-    create_user email: "user@example.com"
+    # create_user email: "user@example.com"
     Quote.create!(text: %Q{Something pithy})
     Quote.create!(text: %Q{Something cool})
-
-    visit root_path
-    click_on "Login"
-    fill_in "Email", with: "user@example.com"
-    fill_in "Password", with: "password"
-    click_on "Login"
-
+    login
     expect(page).to have_content("Something pithy")
     expect(page).to have_content("Something cool")
+  end
+  scenario 'quotes will be created_at now()' do
+    Quote.create!(text: %Q{Something cool})
+    login
+    expect(find('div.created')).to have_content(/less than a minute/)
   end
 
 end

--- a/spec/support/object_creation_methods.rb
+++ b/spec/support/object_creation_methods.rb
@@ -6,3 +6,12 @@ def create_user(overrides = {})
     password_confirmation: 'password'
   }.merge(overrides))
 end
+
+def login
+	create_user email:"user@example.com"
+	visit root_path
+	click_on "Login"
+	fill_in "Email", with: "user@example.com"
+	fill_in "Password", with: "password"
+	click_on "Login"
+end


### PR DESCRIPTION
The database was missing several timestamps that are required to render the quotes table that a user is shown upon logging in. Since these were missing, login attempts failed and rendered an error. I added data to these fields in the production.sql file. I also added testing code to confirm that login is functional and the quotes table renders properly with the new data.
